### PR TITLE
Add minimum number of bandpasses to `DecentVROFilter`

### DIFF
--- a/ampel/contrib/hu/t0/DecentVroFilter.py
+++ b/ampel/contrib/hu/t0/DecentVroFilter.py
@@ -234,8 +234,7 @@ class DecentVroFilter(CatalogMatchUnit, AbsAlertFilter):
             return None
 
         if self.min_n_filters and (
-            (n_filters := np.unique([pp["band"] for pp in pps]).size)
-            < self.min_n_filters
+            (n_filters := len({pp["band"] for pp in pps})) < self.min_n_filters
         ):
             self.logger.debug(None, extra={"n_filters": n_filters})
             return None

--- a/ampel/contrib/hu/t0/DecentVroFilter.py
+++ b/ampel/contrib/hu/t0/DecentVroFilter.py
@@ -40,6 +40,9 @@ class DecentVroFilter(CatalogMatchUnit, AbsAlertFilter):
     min_tspan: float  # minimum duration of alert detection history [days]
     max_tspan: float  # maximum duration of alert detection history [days]
 
+    # Require observations in at least n filters
+    min_n_filters: None | int = None
+
     # Rejects alert with multiple recent detections.
     # Can be caused by hitting the same field, so multiple photopoints in
     # the same band will not provide new information but polute the system.
@@ -228,6 +231,13 @@ class DecentVroFilter(CatalogMatchUnit, AbsAlertFilter):
             self.logger.debug(
                 None, extra={"reliability": latest.get("reliability", None)}
             )
+            return None
+
+        if self.min_n_filters and (
+            (n_filters := np.unique([pp["band"] for pp in pps]).size)
+            < self.min_n_filters
+        ):
+            self.logger.debug(None, extra={"n_filters": n_filters})
             return None
 
         if self.min_ndet_cadence is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ampel-hu-astro"
-version = "0.10.0a23"
+version = "0.10.0a24"
 description = "Astronomy units for the Ampel system from HU-Berlin"
 requires-python = ">=3.12, <4"
 authors = [


### PR DESCRIPTION
I would like to have the possibility to filter by the number of observations in different filters. This would be best inside the `DecentVROFilter`, so I added a `min_n_filters` field to it.