### PR TITLE
Add model for remote data

### DIFF
--- a/ampel/contrib/hu/t2/T2BaseClassifier.py
+++ b/ampel/contrib/hu/t2/T2BaseClassifier.py
@@ -8,6 +8,7 @@
 # Last Modified By:    jnordin@physik.hu-berlin.de
 
 import os
+from pathlib import Path
 from typing import Any
 
 import joblib
@@ -29,6 +30,7 @@ from ampel.contrib.hu.model.ParsnipRiseDeclineResult import (
     ParsnipResult,
     PredictionEntry,
 )
+from ampel.model.ExternalDataModel import ExternalDataModel
 from ampel.model.PlotSpec import PlotSpec
 from ampel.model.UnitModel import UnitModel
 
@@ -72,13 +74,22 @@ parsnip_taxonomy = {
 
 
 class ParsnipModelFiles(TypedDict):
-    model: str
-    classifier: str
+    model: str | ExternalDataModel
+    classifier: str | ExternalDataModel
 
 
 class XgbMultiModelFiles(TypedDict):
-    path: str
+    path: str | ExternalDataModel
     classes: list[int | str]
+
+
+def get_local_path(path: str | ExternalDataModel) -> Path:
+    """
+    Return the local path to a file, downloading it if necessary.
+    """
+    if isinstance(path, ExternalDataModel):
+        return path.local_path()
+    return Path(path)
 
 
 def create_parsnip_plot(
@@ -238,7 +249,7 @@ class T2BaseClassifier:
     classifier_version: str
 
     ## Paths to classifiers to load.
-    paths_xgbbinary: dict[str, str] = {}
+    paths_xgbbinary: dict[str, str | ExternalDataModel] = {}
     paths_xgbmulti: dict[str, XgbMultiModelFiles] = {}
     paths_parsnip: dict[str, ParsnipModelFiles] = {}
 
@@ -259,16 +270,24 @@ class T2BaseClassifier:
 
     def read_class_models(self) -> None:
         self._class_xgbbinary = {
-            label: joblib.load(path) for label, path in self.paths_xgbbinary.items()
+            label: joblib.load(get_local_path(path))
+            for label, path in self.paths_xgbbinary.items()
         }
         self._class_xgbmulti: dict[str, Any] = {
-            label: {**joblib.load(pathdir["path"]), "classes": pathdir["classes"]}
+            label: {
+                **joblib.load(get_local_path(pathdir["path"])),
+                "classes": pathdir["classes"],
+            }
             for label, pathdir in self.paths_xgbmulti.items()
         }
         self._class_parsnip = {
             label: {
-                "classifier": parsnip.Classifier.load(paths["classifier"]),
-                "model": parsnip.load_model(paths["model"], threads=1),
+                "classifier": parsnip.Classifier.load(
+                    get_local_path(paths["classifier"])
+                ),
+                "model": parsnip.load_model(
+                    str(get_local_path(paths["model"])), threads=1
+                ),
             }
             for label, paths in self.paths_parsnip.items()
         }

--- a/ampel/model/ExternalDataModel.py
+++ b/ampel/model/ExternalDataModel.py
@@ -1,0 +1,104 @@
+import os
+from functools import cache, lru_cache
+from hashlib import md5 as _md5
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated, ClassVar
+from urllib.parse import urlparse
+
+import requests
+from pydantic import Field
+
+from ampel.base.AmpelBaseModel import AmpelBaseModel
+
+if TYPE_CHECKING:
+    from glide_sync import GlideClient
+
+
+class ExternalDataModel(AmpelBaseModel):
+    name: Annotated[str, Field(description="Name of the file")]
+    url: Annotated[str, Field(description="URL of the file")]
+    md5: Annotated[
+        str, Field(description="MD5 hash of the file", pattern=r"^[a-fA-F0-9]{32}$")
+    ]
+
+    _cache: ClassVar[dict[tuple[str, str, str], Path]] = {}
+
+    @staticmethod
+    @cache
+    def _get_valkey() -> "GlideClient | None":
+        url = os.getenv("VALKEY_URL")
+        if not url:
+            return None
+        parts = urlparse(url)
+        if (hostname := parts.hostname) is None:
+            return None
+
+        try:
+            from glide_sync import (  # noqa: PLC0415
+                GlideClient,
+                GlideClientConfiguration,
+                NodeAddress,
+            )
+        except ImportError:
+            return None
+
+        return GlideClient.create(
+            GlideClientConfiguration(
+                [NodeAddress(host=hostname, port=parts.port or 6379)]
+            )
+        )
+
+    @staticmethod
+    @lru_cache(maxsize=1024)
+    def _file_md5(path: Path) -> str:
+        h = _md5()
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+    def local_path(self) -> Path:
+        """
+        Get the local path to the file, downloading it if necessary."""
+        key = (self.name, self.url, self.md5)
+        cached = self._cache.get(key)
+        if cached and cached.exists() and self._file_md5(cached) == self.md5:
+            return cached
+
+        path = Path(self.name)
+        if path.exists():
+            if self._file_md5(path) == self.md5:
+                self._cache[key] = path
+                return path
+            raise ValueError(
+                f"{path} exists, but MD5 does not match expected value for {self.url}. "
+                "Remove the file or change the name to download a new version."
+            )
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        valkey = self._get_valkey()
+        if valkey and (content := valkey.get(self.url)):
+            with path.open("wb") as f:
+                f.write(content)
+        else:
+            with (
+                requests.get(self.url, stream=True) as response,
+                path.open("wb") as out,
+            ):
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        out.write(chunk)
+            if valkey:
+                # NB: values must be smaller than 512MB
+                valkey.set(self.url, path.read_bytes())
+
+        if self._file_md5(path) != self.md5:
+            path.unlink(missing_ok=True)
+            if valkey:
+                valkey.delete([self.url])
+            raise ValueError(
+                f"MD5 mismatch for {self.url}: expected {self.md5}, got {self._file_md5(path)}"
+            )
+
+        self._cache[key] = path
+        return path

--- a/examples/vroprep_lsstarchive_single_t0.yml
+++ b/examples/vroprep_lsstarchive_single_t0.yml
@@ -122,14 +122,14 @@ task:
                   parsnip_zeropoint_offset: 0
                   paths_parsnip:
                     sn+2ulens+dwarfs:
-                      # https://box.hu-berlin.de/f/78d7594841da4653a743/?dl=1
-                      # box name: parsnipModelAug10Pct30.h5
-                      # old name: model1-30pct-sn+2ulens+dwarfs-mw.h5
-                      model: /Users/jnordin/github/ampelFeb25/Ampel-HU-astro/examples/parsnipModelAug10Pct30.h5
-                      # https://box.hu-berlin.de/f/d1cec88c0bec4123b208/?dl=1
-                      # box name: parsnipClassifierAug10Pct30.pkl 
-                      # old name: model1-30pct-sn+2ulens+dwarfs-mw-aug10.pkl
-                      classifier: /Users/jnordin/github/ampelFeb25/Ampel-HU-astro/examples/parsnipClassifierAug10Pct30.pkl
+                      model:
+                        name: parsnipModelAug10Pct30.h5
+                        url: https://zenodo.org/records/21134332/files/parsnipModelAug10Pct30.h5?download=1
+                        md5: 906be58422ad76b0eb9e3b433fa16caf
+                      classifier:
+                        name: parsnipClassifierAug10Pct30.pkl
+                        url: https://zenodo.org/records/21134332/files/parsnipClassifierAug10Pct30.pkl?download=1
+                        md5: dd4a75626d98ffd2d0e85a13fcb6171c
                   paths_xgbbinary: {}
                   paths_xgbmulti: {}
 #                  redshift_kind: null 

--- a/poetry.lock
+++ b/poetry.lock
@@ -741,7 +741,7 @@ files = [
     {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
     {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
 ]
-markers = {main = "platform_python_implementation != \"PyPy\" and (extra == \"elasticc\" or extra == \"lsst\" or extra == \"ligo\" or extra == \"ztf\")"}
+markers = {main = "(platform_python_implementation != \"PyPy\" or extra == \"valkey\") and (extra == \"elasticc\" or extra == \"lsst\" or extra == \"ligo\" or extra == \"ztf\" or extra == \"valkey\")"}
 
 [package.dependencies]
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
@@ -5109,7 +5109,7 @@ description = ""
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"snpy\""
+markers = "extra == \"snpy\" or extra == \"valkey\""
 files = [
     {file = "protobuf-6.33.4-cp310-abi3-win32.whl", hash = "sha256:918966612c8232fc6c24c78e1cd89784307f5814ad7506c308ee3cf86662850d"},
     {file = "protobuf-6.33.4-cp310-abi3-win_amd64.whl", hash = "sha256:8f11ffae31ec67fc2554c2ef891dcb561dae9a2a3ed941f9e134c2db06657dbc"},
@@ -5311,7 +5311,7 @@ files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
-markers = {main = "platform_python_implementation != \"PyPy\" and (extra == \"elasticc\" or extra == \"lsst\" or extra == \"ligo\" or extra == \"ztf\") and implementation_name != \"PyPy\"", notebook = "implementation_name != \"PyPy\""}
+markers = {main = "(platform_python_implementation != \"PyPy\" or extra == \"valkey\") and implementation_name != \"PyPy\" and (extra == \"elasticc\" or extra == \"lsst\" or extra == \"ligo\" or extra == \"ztf\" or extra == \"valkey\")", notebook = "implementation_name != \"PyPy\""}
 
 [[package]]
 name = "pydantic"
@@ -7719,6 +7719,51 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
+name = "valkey-glide-sync"
+version = "2.4.2"
+description = "Valkey GLIDE Sync client. Supports Valkey and Redis OSS."
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "extra == \"valkey\""
+files = [
+    {file = "valkey_glide_sync-2.4.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:dcc716698a6b298e8280839f67de08f2b69e9fde69deb591d87d47ac003c93b2"},
+    {file = "valkey_glide_sync-2.4.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e6903b240671e557265242ad61fbad24d72f7fb2e9227e5c9fb37dbf0d21b406"},
+    {file = "valkey_glide_sync-2.4.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:327f8ba3a5dbf548b064ad0cd5bf1f48dcabaedf9b9bf071428a617c79420118"},
+    {file = "valkey_glide_sync-2.4.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:49006a80daf67e5adfff220f023e163fe0a05c71a24c2c93557909bf33da9ab4"},
+    {file = "valkey_glide_sync-2.4.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6f7882a3ad26244d37db6488e6b4d6ae28e3a7583cbc1f25992272412b64fbc7"},
+    {file = "valkey_glide_sync-2.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0cc6de84d0afcfd767c671a35fc9570beb97833ecf89cd5d887a871aa09f5fb4"},
+    {file = "valkey_glide_sync-2.4.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:aeaa6187640d09074935ff7eee462efd936b75e961f14bf3371d3122ccec3b82"},
+    {file = "valkey_glide_sync-2.4.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06f27ff7b71c5a2aa96fe0a2f46bfc66ff018c1911180987304841678ea0bc99"},
+    {file = "valkey_glide_sync-2.4.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bd83e2796b4ad32e9c5d1bc505f3671d26008364d153cce070f463fe75fc74f5"},
+    {file = "valkey_glide_sync-2.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ccd15a1b77d578ff12a1eeab3c0ab7165c69da6ec825f5af38f2d009512a5510"},
+    {file = "valkey_glide_sync-2.4.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c9e71c111564224f32e7d560ea210122c54dd63d641976de56264cad843a0afb"},
+    {file = "valkey_glide_sync-2.4.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:75af5bf5389d0274cc5f12952ad17f451d0c6ba3cdbb8a4258de48c8a156717e"},
+    {file = "valkey_glide_sync-2.4.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4429cc1f2efa2087c5ef45a6ed063df243cd65fee56e07e530e7e68d9c7eb4b8"},
+    {file = "valkey_glide_sync-2.4.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:193e720b5fdb7368520941b459c6e8f1554bf424f16babee4220a5ead6764364"},
+    {file = "valkey_glide_sync-2.4.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c403c244cb4b7df12ded137107af5ebd3fa60ab56420b23baeab279b9b76b57d"},
+    {file = "valkey_glide_sync-2.4.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:27795dfe0af684071457572de92ab8ebdd8a8a0929944b594e06db8ee07160ac"},
+    {file = "valkey_glide_sync-2.4.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f28ddc88bc03a76e0803b208e3590de608d34bbaedf66fa46a0cf1e380b04439"},
+    {file = "valkey_glide_sync-2.4.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7c2894eb293e508c06bd651b1e6e80c6022ef570fcb61ecd80104aeb0e95ad8f"},
+    {file = "valkey_glide_sync-2.4.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9e378ee93f05bd020fb03330762039da830502e795200b543e42573a8cbb1c61"},
+    {file = "valkey_glide_sync-2.4.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b24baa7bdfef892d3c151971103bd037524c1c8b5d09d102c197791e4c860eb6"},
+    {file = "valkey_glide_sync-2.4.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:cdf5c09a19e02e52a051a9da9ac61459869ebac195a45aac7c63c040b9dda79f"},
+    {file = "valkey_glide_sync-2.4.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4b5184f3056899c8beb0c33905a8d7f64edaf8d7f876a741f3a325556ae314f1"},
+    {file = "valkey_glide_sync-2.4.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f07d7ec9b3b0d7b5941898e44e584d53913389a0d1e333fb917094691fa81ef3"},
+    {file = "valkey_glide_sync-2.4.2-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f41ef1b4a925410290bf6315f593ece6cd6c11129699411e65eb128aca7a58b7"},
+    {file = "valkey_glide_sync-2.4.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:49a3a5544b86221b4a67317721feeb2bcc86fa22b90abfae4099101ce405c722"},
+    {file = "valkey_glide_sync-2.4.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:e8be397fd7464983bef11e262d6c49503f70cd1b17cb2cdc02b170914a752757"},
+    {file = "valkey_glide_sync-2.4.2-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:af221d354a21ca86c45f9af75db7fae49e84a8687fd918742f0564a3f3e28eaa"},
+    {file = "valkey_glide_sync-2.4.2-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b1768d4951b8a7530191bfb3bf90f74951e1f1025757bb056c7cdc27ab301ae6"},
+    {file = "valkey_glide_sync-2.4.2.tar.gz", hash = "sha256:0bb00f3f3ff2e295519e0fd7741c39e3fffe14e62f3672589215d2145582c327"},
+]
+
+[package.dependencies]
+cffi = ">=1.0.0"
+protobuf = ">=3.20"
+typing-extensions = ">=4.8.0"
+
+[[package]]
 name = "wcwidth"
 version = "0.5.0"
 description = "Measures the displayed width of unicode strings in a terminal"
@@ -8041,9 +8086,10 @@ lsst = ["ampel-lsst"]
 slack = ["slack-sdk"]
 sncosmo = ["iminuit", "sfdmap2", "sncosmo"]
 snpy = ["snpy"]
+valkey = ["valkey-glide-sync"]
 ztf = ["ampel-ztf", "ztfquery"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12, <4"
-content-hash = "d8c463efdcdb000000864b774c82bfbf5522f4b0610ee4a6c52f6f9c42294f28"
+content-hash = "11e835aeed913519c27652af1cd9047f6ed82ba9a9e94c6ccda3810cdb7d9a1d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ampel-hu-astro"
-version = "0.10.0a24"
+version = "0.10.0a25"
 description = "Astronomy units for the Ampel system from HU-Berlin"
 requires-python = ">=3.12, <4"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ hop = [
     "py-avro-schema (>=3.8.2,<4.0.0)",
 ]
 lasair = ["lasair (>=0.1.2,<0.2.0)"]
+valkey = ["valkey-glide-sync (>=2.4.2,<3.0.0)"]
 [dependency-groups]
 dev = [
     "pytest-ampel-core (>=0.10.0a7,<0.11)",

--- a/tests/test_ExternalDataModel.py
+++ b/tests/test_ExternalDataModel.py
@@ -1,0 +1,50 @@
+import secrets
+from base64 import b64encode
+from hashlib import md5
+from unittest.mock import MagicMock
+
+from pytest_mock import MockerFixture
+from requests import Response
+
+from ampel.model.ExternalDataModel import ExternalDataModel
+
+
+def test_download(tmpdir, mocker: MockerFixture):
+
+    content = secrets.token_bytes(36)
+    md5_hash = md5(content).hexdigest()
+
+    # do not actually call out to httpbin
+    response = Response()
+    response.raise_for_status = lambda: None
+    response.iter_content = lambda chunk_size: [content]
+    response.raw = MagicMock()
+    get = mocker.patch(
+        "ampel.model.ExternalDataModel.requests.get", return_value=response
+    )
+
+    # NB: use urlsafe altchars, the same encoding as httpbin assumes
+    url = f"https://httpbin.org/base64/{b64encode(content, altchars=b'-_').decode()}"
+
+    m = ExternalDataModel(
+        name=str(tmpdir / "test.txt"),
+        url=url,
+        md5=md5_hash,
+    )
+    path = m.local_path()
+    assert get.call_count == 1
+    assert path.exists()
+
+    assert path.read_bytes() == content
+
+    m._cache.clear()
+    path = m.local_path()
+    assert path.exists()
+    assert get.call_count == 1  # no new download
+
+    path.unlink()
+    assert not path.exists()
+
+    m.local_path()
+    assert path.read_bytes() == content
+    assert get.call_count == 2  # new download after file was deleted


### PR DESCRIPTION
So far, we've been specifying external data files like ParSNIP models as strings, sometimes with comments indicating where the files should be downloaded from. This is problematic for both usability and provenance, as the provided examples don't work out of the box, and could return different results if a file with the name expected by a job (but different contents) happens to exist on the filesystem.

Input artifacts were an attempt to solve this problem by letting a job specify files to be placed in the working directory of the job, but they were removed in https://github.com/AmpelProject/Ampel-core/commit/1968f958934c08f65293a2c743f5e6b17929b68d.

This PR takes a different approach, providing an explicit `ExternalDataModel` for a remote file consisting of a local filename, a url, and an expected md5 checksum. `ExternalDataModel` provides one user-facing method, `local_path()`, that does the following:
1. Check if the file exists at the expected path. If it does and the checksum matches, return the path. If the checksum does not match, raise an exception.
2. If a Valkey cache was configured, retrieve from the cache and write to a local file. Otherwise, download from the url, write to a local file, and write to cache if configured.
3. Verify the checksum. Return the path if it matches, otherwise delete the local file and cache entry and raise an exception.

Valkey caching is optional, but critical for production: 200 workers starting in parallel and all downloading ~50 MB of data is a low-grade denial-of-service attack. Cache entries are set to never expire, as we assume that URLs point to immutable data.

If this proves useful, it should likely be pushed down into Ampel-core.