### PR TITLE
Preserve numpy.int64 values passed to PhotometricPoint.id

### DIFF
--- a/ampel/contrib/hu/t2/T2LSSTReport.py
+++ b/ampel/contrib/hu/t2/T2LSSTReport.py
@@ -99,7 +99,7 @@ class T2LSSTReport(AbsTiedStateT2Unit, AbsTabulatedT2Unit, abstract=True):
 
         photometry = [
             PhotometricPoint(
-                id=id,
+                id=int(id),
                 source=source,
                 time=time,
                 flux=flux,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ampel-hu-astro"
-version = "0.10.0a25"
+version = "0.10.0a26"
 description = "Astronomy units for the Ampel system from HU-Berlin"
 requires-python = ">=3.12, <4"
 authors = [

--- a/tests/test_T2LSSTReport.py
+++ b/tests/test_T2LSSTReport.py
@@ -71,3 +71,16 @@ def test_process(compound, datapoints, ampel_logger, mock_context):
     blob = message.serialize()["content"]
     assert isinstance(blob, bytes)
     assert message.deserialize(blob).content == message.content
+
+    # ensure that ids were not corrupted by secret rounding
+    dp = {
+        doc["body"]["diaSourceId"]: doc for doc in datapoints if "LSST_DP" in doc["tag"]
+    }
+    fp = {
+        doc["body"]["diaForcedSourceId"]: doc
+        for doc in datapoints
+        if "LSST_FP" in doc["tag"]
+    }
+    dps = {"LSST_DP": dp, "LSST_FP": fp}
+    for dp in message.content["photometry"]:
+        assert dp["id"] in dps[dp["source"]]


### PR DESCRIPTION
`numpy.int64` values overflow when passed to `int` field of a pydantic model: https://github.com/pydantic/pydantic/issues/10016

Work around this by explicitly casting to python `int`. 🤬.