### PR TITLE
`LasairAnnotator`: Fix the Rubin Lasair URL

### DIFF
--- a/ampel/contrib/hu/util/LasairAnnotator.py
+++ b/ampel/contrib/hu/util/LasairAnnotator.py
@@ -31,9 +31,10 @@ class LasairAnnotator:
 
     @cached_property
     def lasair_client(self) -> lasair.lasair_client:
+        v = "-ztf" if self.lasair_version == "ztf" else ""
         return lasair.lasair_client(
             self.lasair_api_token.get(),
-            endpoint=f"https://lasair-{self.lasair_version}.lsst.ac.uk/api",
+            endpoint=f"https://lasair{v}.lsst.ac.uk/api",
         )
 
     def annotate(

--- a/ampel/contrib/hu/util/LasairAnnotator.py
+++ b/ampel/contrib/hu/util/LasairAnnotator.py
@@ -56,9 +56,11 @@ class LasairAnnotator:
         if self.check_existence:
             try:
                 self.lasair_client.object(objectId, lite=True)
-            except Exception:
-                # Object not find in Lasair, return.
-                return False
+            except lasair.LasairError as e:
+                if e.message.startswith("HTTP return code 404"):
+                    # Object not find in Lasair, return.
+                    return False
+                raise e
 
         lasairout = self.lasair_client.annotate(
             self.lasair_topic,


### PR DESCRIPTION
The LSST Lasair moved from lasair-lsst.ac.uk to lasair.lsst.ac.uk!